### PR TITLE
Add test for int32 row splits

### DIFF
--- a/src/djcdata/SimpleArray.py
+++ b/src/djcdata/SimpleArray.py
@@ -68,10 +68,10 @@ class SimpleArray(object):
         name = self.name()
         fnames = self.featureNames()
         self._setDtype(str(nparr.dtype))
-        if nprs.dtype == 'int32':
-            self.sa.createFromNumpy(nparr, nprs.as_type('int64')) 
+        if nprs.dtype == np.dtype('int32'):
+            self.sa.createFromNumpy(nparr, nprs.astype('int64'))
         else:
-            self.sa.createFromNumpy(nparr, nprs) 
+            self.sa.createFromNumpy(nparr, nprs)
         self.setName(name)
         self.setFeatureNames(fnames)
     

--- a/test/TestSimpleArray.py
+++ b/test/TestSimpleArray.py
@@ -51,17 +51,32 @@ class TestSimpleArray(unittest.TestCase):
         
     def test_createFromNumpyInt(self):
         print('TestSimpleArray: createFromNumpyInt')
-        
+
         arr,rs = self.createNumpy('int32')
-        
+
         a = SimpleArray(dtype='int32')
         a.createFromNumpy(arr,rs)
-        
+
         narr, nrs = a.copyToNumpy()
         nrs=nrs[:,0]
-        
+
         diff = np.max(np.abs(narr-arr))
         diff += np.max(np.abs(nrs-rs))
+        self.assertTrue(diff< 0.000001)
+
+    def test_createFromNumpy_rowsplits_int32(self):
+        print('TestSimpleArray: createFromNumpy_rowsplits_int32')
+        arr = np.array(np.random.rand(500,3,5,6)*100., dtype='float32')
+        rs = np.array([0,100,230,500], dtype='int32')
+
+        a = SimpleArray(dtype='float32')
+        a.createFromNumpy(arr,rs)
+
+        narr, nrs = a.copyToNumpy()
+        nrs = nrs[:,0]
+
+        diff = np.max(np.abs(narr-arr))
+        diff += np.max(np.abs(nrs-rs.astype('int64')))
         self.assertTrue(diff< 0.000001)
         
     def test_dynamicTypeChange(self):


### PR DESCRIPTION
## Summary
- allow `SimpleArray.createFromNumpy` to accept `int32` row-splits by casting to `int64`
- add regression test for round-tripping arrays with `int32` row-splits

## Testing
- `PYTHONPATH=src python test/runtests.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6892fa47d348832f929da43bb75fa0c6